### PR TITLE
Silently handle timeouts from Tiko API

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -32,6 +32,12 @@
         "title": "Identifiant de propriété (facultatif)",
         "type": "number",
         "required": false
+      },
+      "timeout": {
+        "title": "Timeout (ms)",
+        "type": "number",
+        "required": false,
+        "placeholder": "1000"
       }
     }
   }

--- a/src/TikoAPI.test.ts
+++ b/src/TikoAPI.test.ts
@@ -8,6 +8,7 @@ import {setTemperatureQuery} from './queries/setTemperatureQuery';
 import {authenticationQuery} from './queries/authenticationQuery';
 import {setRoomModeQuery} from './queries/setRoomMode';
 import {TikoApiError} from './TikoApiError';
+import {TimeoutError} from './timeout/TimeoutError';
 
 jest.mock('@apollo/client/core');
 
@@ -267,6 +268,28 @@ describe('#getRoom', () => {
 
     // then
     await expect(promise).rejects.toEqual(new TikoApiError('An error occurred'));
+  });
+
+  test('catches TimeoutError and throws TikoApiError', async () => {
+    // given
+    const configMock = {
+      platform: 'Tiko',
+      login: 'user@example.net',
+      password: 'p4ssw0rd',
+      propertyId: 789,
+      timeout: 2500,
+    } as PlatformConfig;
+    const clientMock = _mockClientAndRespond(null);
+    const error = new TimeoutError(2500);
+    clientMock.query.mockRejectedValue(error);
+
+    const tikoApi = new TikoAPI(configMock, clientMock);
+
+    // when
+    const promise = tikoApi.getRoom(1);
+
+    // then
+    await expect(promise).rejects.toEqual(new TikoApiError('Timeout of 2500 ms exceeded'));
   });
 });
 

--- a/src/TikoAPI.ts
+++ b/src/TikoAPI.ts
@@ -111,11 +111,14 @@ export default class TikoAPI {
   }
 
   static build(config: PlatformConfig): TikoAPI {
-    const client = new ApolloClient({
+    const client = this._createApolloClient();
+    return new TikoAPI(config, client);
+  }
+
+  protected static _createApolloClient() {
+    return new ApolloClient({
       cache: new InMemoryCache(),
     });
-
-    return new TikoAPI(config, client);
   }
 
   private static _createApolloLink(config: PlatformConfig, userToken: string | null = null): ApolloLink {

--- a/src/TikoApiWithThrottle.test.ts
+++ b/src/TikoApiWithThrottle.test.ts
@@ -1,0 +1,35 @@
+import TikoApiWithThrottle from './TikoApiWithThrottle';
+import {PlatformConfig} from 'homebridge';
+import {ApolloClient, NormalizedCacheObject} from '@apollo/client/core';
+
+jest.mock('@apollo/client/core');
+
+describe('#getRoom', () => {
+  test('calls API only once for identical requests', async () => {
+    // given
+    const config = {} as PlatformConfig;
+    const client = {
+      query: jest.fn(() => new Promise((resolve) => {
+        setTimeout(() => resolve({
+          data: {
+            property: {
+              room: {},
+            },
+          },
+        }), 1000);
+      })),
+      setLink: jest.fn(),
+    } as unknown as jest.Mocked<ApolloClient<NormalizedCacheObject>>;
+    const apiWithThrottle = new TikoApiWithThrottle(config, client);
+
+    // when
+    await Promise.all([
+      apiWithThrottle.getRoom(1),
+      apiWithThrottle.getRoom(1),
+      apiWithThrottle.getRoom(2),
+    ]);
+
+    // then
+    expect(client.query).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/TikoApiWithThrottle.ts
+++ b/src/TikoApiWithThrottle.ts
@@ -1,0 +1,32 @@
+import TikoAPI from './TikoAPI';
+import {TikoRoom} from './types';
+import {PlatformConfig} from 'homebridge';
+
+type RoomRequest = {
+  promise: Promise<TikoRoom>;
+  roomId: number;
+};
+
+export default class TikoApiWithThrottle extends TikoAPI {
+  private currentRequests: RoomRequest[] = [];
+
+  async getRoom(roomId: number): Promise<TikoRoom> {
+    const currentRequestForRoom = this.currentRequests.find(request => request.roomId === roomId);
+    if (currentRequestForRoom) {
+      return currentRequestForRoom.promise;
+    }
+
+    const roomPromise = super.getRoom(roomId);
+    this.currentRequests.push({ promise: roomPromise, roomId });
+
+    const room = await roomPromise;
+    this.currentRequests = this.currentRequests.filter(request => request.roomId === room.id);
+
+    return room;
+  }
+
+  static build(config: PlatformConfig): TikoApiWithThrottle {
+    const client = this._createApolloClient();
+    return new TikoApiWithThrottle(config, client);
+  }
+}

--- a/src/TikoPlatform.test.ts
+++ b/src/TikoPlatform.test.ts
@@ -2,6 +2,7 @@ import TikoAPI from './TikoAPI';
 import {API, Logger, PlatformConfig} from 'homebridge';
 import {TikoPlatform} from './TikoPlatform';
 import {TikoApiError} from './TikoApiError';
+import TikoApiWithThrottle from './TikoApiWithThrottle';
 
 jest.mock('./TikoAPI');
 
@@ -59,8 +60,8 @@ describe('#discoverDevices', () => {
     const tikoApiMock = {
       authenticate: jest.fn(),
       getAllRooms: jest.fn(() => []),
-    } as unknown as TikoAPI;
-    TikoAPI.build = jest.fn(() => tikoApiMock);
+    } as unknown as TikoApiWithThrottle;
+    TikoApiWithThrottle.build = jest.fn(() => tikoApiMock);
 
     const tikoPlatform = new TikoPlatform(logMock, configMock, homebridgeApi);
 
@@ -68,7 +69,7 @@ describe('#discoverDevices', () => {
     await tikoPlatform.discoverDevices();
 
     // then
-    expect(TikoAPI.build).toHaveBeenCalled();
+    expect(TikoApiWithThrottle.build).toHaveBeenCalled();
     expect(tikoApiMock.authenticate).toHaveBeenCalled();
     expect(tikoApiMock.getAllRooms).toHaveBeenCalled();
   });
@@ -87,8 +88,8 @@ describe('#discoverDevices', () => {
     const tikoApiMock = {
       authenticate: jest.fn().mockRejectedValue(new TikoApiError('Oops!')),
       getAllRooms: jest.fn(() => []),
-    } as unknown as TikoAPI;
-    TikoAPI.build = jest.fn(() => tikoApiMock);
+    } as unknown as TikoApiWithThrottle;
+    TikoApiWithThrottle.build = jest.fn(() => tikoApiMock);
 
     const tikoPlatform = new TikoPlatform(logMock, configMock, homebridgeApi);
 

--- a/src/TikoPlatform.test.ts
+++ b/src/TikoPlatform.test.ts
@@ -97,7 +97,7 @@ describe('#discoverDevices', () => {
     await tikoPlatform.discoverDevices();
 
     // then
-    expect(logMock.error).toHaveBeenCalledWith('An error occured while trying to login: Oops!');
+    expect(logMock.error).toHaveBeenCalledWith('An error occurred while trying to login: Oops!');
     expect(tikoApiMock.getAllRooms).not.toHaveBeenCalled();
   });
 });

--- a/src/TikoPlatform.ts
+++ b/src/TikoPlatform.ts
@@ -53,7 +53,7 @@ export class TikoPlatform implements DynamicPlatformPlugin {
       this.log.debug(`Successfully logged in with account ${this.config.login}.`);
     } catch(error) {
       if (error instanceof TikoApiError) {
-        this.log.error(`An error occured while trying to login: ${error.message}`);
+        this.log.error(`An error occurred while trying to login: ${error.message}`);
         return;
       }
     }

--- a/src/TikoPlatform.ts
+++ b/src/TikoPlatform.ts
@@ -2,22 +2,22 @@ import {API, DynamicPlatformPlugin, Logger, PlatformAccessory, PlatformConfig, S
 
 import {PLATFORM_NAME, PLUGIN_NAME} from './settings';
 import {TikoAccessory} from './TikoAccessory';
-import TikoAPI from './TikoAPI';
 import {TikoRoom} from './types';
 import {TikoApiError} from './TikoApiError';
+import TikoApiWithThrottle from './TikoApiWithThrottle';
 
 export class TikoPlatform implements DynamicPlatformPlugin {
   public readonly Service: typeof Service = this.api.hap.Service;
   public readonly Characteristic: typeof Characteristic = this.api.hap.Characteristic;
   public readonly accessories: PlatformAccessory[] = [];
-  public readonly tiko: TikoAPI;
+  public readonly tiko: TikoApiWithThrottle;
 
   constructor(
     public readonly log: Logger,
     public readonly config: PlatformConfig,
     public readonly api: API,
   ) {
-    this.tiko = TikoAPI.build(config);
+    this.tiko = TikoApiWithThrottle.build(config);
 
     if (!this.config.name) {
       this.log.error('Missing required parameter "name" in config');

--- a/src/timeout/TimeoutError.ts
+++ b/src/timeout/TimeoutError.ts
@@ -1,0 +1,9 @@
+export class TimeoutError implements Error {
+  message: string;
+  name: string;
+
+  constructor(timeLimitInMs: number) {
+    this.message = `Timeout of ${timeLimitInMs} ms exceeded`;
+    this.name = 'TikoApiError';
+  }
+}

--- a/src/timeout/awaitUntilTimeout.test.ts
+++ b/src/timeout/awaitUntilTimeout.test.ts
@@ -1,0 +1,27 @@
+import {awaitUntilTimeout} from './awaitUntilTimeout';
+import {TimeoutError} from './TimeoutError';
+
+describe('#awaitUntilTimeout', () => {
+  test('resolves if given promise resolve before timeout', async () => {
+    // given
+    const promiseValue = Symbol();
+    const givenPromise = new Promise((resolve) => setTimeout(() => resolve(promiseValue), 100));
+
+    // when
+    const resultPromise = awaitUntilTimeout(givenPromise, 1000);
+
+    // then
+    await expect(resultPromise).resolves.toEqual(promiseValue);
+  });
+
+  test('rejects if given promise does not resolve before timeout', async () => {
+    // given
+    const givenPromise = new Promise((resolve) => setTimeout(resolve, 1000));
+
+    // when
+    const resultPromise = awaitUntilTimeout(givenPromise, 100);
+
+    // then
+    await expect(resultPromise).rejects.toBeInstanceOf(TimeoutError);
+  });
+});

--- a/src/timeout/awaitUntilTimeout.ts
+++ b/src/timeout/awaitUntilTimeout.ts
@@ -1,0 +1,18 @@
+import {TimeoutError} from './TimeoutError';
+
+export async function awaitUntilTimeout(promise: Promise<unknown>, timeLimitInMs = 1000): Promise<unknown> {
+  let timer: NodeJS.Timeout | null = null;
+  try {
+    const timeoutPromise = new Promise((_, reject) => {
+      timer = setTimeout(reject, timeLimitInMs, new TimeoutError(timeLimitInMs));
+    });
+    return await Promise.race([
+      promise,
+      timeoutPromise,
+    ]);
+  } finally {
+    if (timer) {
+      clearTimeout(timer);
+    }
+  }
+}


### PR DESCRIPTION
- refactor: extract method callTikoApi
- feat: add awaitUntilTimeout helper
- feat: add config option to set timeout
- feat: wait for Tiko response until timeout
- refactor: extract method _createApolloClient
- feat: add TikoApiWithThrottle middleware
- feat: throttles identital request to Tiko API
- fix: use correct spelling in error message
